### PR TITLE
Add SASL support for Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Python 3.7+
 - `Broadcast("redis://localhost:6379")`
 - `Broadcast("postgres://localhost:5432/broadcaster")`
 - `Broadcast("kafka://localhost:9092")`
+- `Broadcast("kafka://broker_1:9092,broker_2:9092")`
 
 ## Kafka environment variables
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a fork of [encode/broadcaster](https://github.com/encode/broadcaster).
 
----
+----
 
 Broadcaster helps you develop realtime streaming functionality by providing
 a simple broadcast API onto a number of different backend services.
@@ -73,18 +73,18 @@ Python 3.7+
 
 ## Installation
 
-- `pip install permit-broadcaster`
-- `pip install permit-broadcaster[redis]`
-- `pip install permit-broadcaster[postgres]`
-- `pip install permit-broadcaster[kafka]`
+* `pip install permit-broadcaster`
+* `pip install permit-broadcaster[redis]`
+* `pip install permit-broadcaster[postgres]`
+* `pip install permit-broadcaster[kafka]`
 
 ## Available backends
 
-- `Broadcast('memory://')`
-- `Broadcast("redis://localhost:6379")`
-- `Broadcast("postgres://localhost:5432/broadcaster")`
-- `Broadcast("kafka://localhost:9092")`
-- `Broadcast("kafka://broker_1:9092,broker_2:9092")`
+* `Broadcast('memory://')`
+* `Broadcast("redis://localhost:6379")`
+* `Broadcast("postgres://localhost:5432/broadcaster")`
+* `Broadcast("kafka://localhost:9092")`
+* `Broadcast("kafka://broker_1:9092,broker_2:9092")`
 
 ## Kafka environment variables
 
@@ -103,12 +103,12 @@ For full details refer to the (AIOKafka options)[https://aiokafka.readthedocs.io
 
 At the moment `broadcaster` is in Alpha, and should be considered a working design document.
 
-The API should be considered subject to change. If you _do_ want to use Broadcaster in its current
+The API should be considered subject to change. If you *do* want to use Broadcaster in its current
 state, make sure to strictly pin your requirements to `broadcaster==0.2.0`.
 
 To be more capable we'd really want to add some additional backends, provide API support for reading recent event history from persistent stores, and provide a serialization/deserialization API...
 
 - Serialization / deserialization to support broadcasting structured data.
 - Backends for Redis Streams, Apache Kafka, and RabbitMQ.
-- Add support for `subscribe('chatroom', history=100)` for backends which provide persistence. (Redis Streams, Apache Kafka) This will allow applications to subscribe to channel updates, while also being given an initial window onto the most recent events. We _might_ also want to support some basic paging operations, to allow applications to scan back in the event history.
+- Add support for `subscribe('chatroom', history=100)` for backends which provide persistence. (Redis Streams, Apache Kafka) This will allow applications to subscribe to channel updates, while also being given an initial window onto the most recent events. We *might* also want to support some basic paging operations, to allow applications to scan back in the event history.
 - Support for pattern subscribes in backends that support it.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ state, make sure to strictly pin your requirements to `broadcaster==0.2.0`.
 
 To be more capable we'd really want to add some additional backends, provide API support for reading recent event history from persistent stores, and provide a serialization/deserialization API...
 
-- Serialization / deserialization to support broadcasting structured data.
-- Backends for Redis Streams, Apache Kafka, and RabbitMQ.
-- Add support for `subscribe('chatroom', history=100)` for backends which provide persistence. (Redis Streams, Apache Kafka) This will allow applications to subscribe to channel updates, while also being given an initial window onto the most recent events. We *might* also want to support some basic paging operations, to allow applications to scan back in the event history.
-- Support for pattern subscribes in backends that support it.
+* Serialization / deserialization to support broadcasting structured data.
+* Backends for Redis Streams, Apache Kafka, and RabbitMQ.
+* Add support for `subscribe('chatroom', history=100)` for backends which provide persistence. (Redis Streams, Apache Kafka) This will allow applications to subscribe to channel updates, while also being given an initial window onto the most recent events. We *might* also want to support some basic paging operations, to allow applications to scan back in the event history.
+* Support for pattern subscribes in backends that support it.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a fork of [encode/broadcaster](https://github.com/encode/broadcaster).
 
-----
+---
 
 Broadcaster helps you develop realtime streaming functionality by providing
 a simple broadcast API onto a number of different backend services.
@@ -73,28 +73,41 @@ Python 3.7+
 
 ## Installation
 
-* `pip install permit-broadcaster`
-* `pip install permit-broadcaster[redis]`
-* `pip install permit-broadcaster[postgres]`
-* `pip install permit-broadcaster[kafka]`
+- `pip install permit-broadcaster`
+- `pip install permit-broadcaster[redis]`
+- `pip install permit-broadcaster[postgres]`
+- `pip install permit-broadcaster[kafka]`
 
 ## Available backends
 
-* `Broadcast('memory://')`
-* `Broadcast("redis://localhost:6379")`
-* `Broadcast("postgres://localhost:5432/broadcaster")`
-* `Broadcast("kafka://localhost:9092")`
+- `Broadcast('memory://')`
+- `Broadcast("redis://localhost:6379")`
+- `Broadcast("postgres://localhost:5432/broadcaster")`
+- `Broadcast("kafka://localhost:9092")`
+
+## Kafka environment variables
+
+The following environment variables are exposed to allow SASL authentication with Kafka (along with their default assignment):
+
+```
+KAFKA_SECURITY_PROTOCOL=PLAINTEXT   # PLAINTEXT, SASL_PLAINTEXT, SASL_SSL
+KAFKA_SASL_MECHANISM=PLAIN   # PLAIN, SCRAM-SHA-256, SCRAM-SHA-512
+KAFKA_PLAIN_USERNAME=None   # any str
+KAFKA_PLAIN_PASSWORD=None   # any str
+```
+
+For full details refer to the (AIOKafka options)[https://aiokafka.readthedocs.io/en/stable/api.html#producer-class] where the variable name matches the capitalised env var with an additional `KAFKA_` prefix.
 
 ## Where next?
 
 At the moment `broadcaster` is in Alpha, and should be considered a working design document.
 
-The API should be considered subject to change. If you *do* want to use Broadcaster in its current
+The API should be considered subject to change. If you _do_ want to use Broadcaster in its current
 state, make sure to strictly pin your requirements to `broadcaster==0.2.0`.
 
 To be more capable we'd really want to add some additional backends, provide API support for reading recent event history from persistent stores, and provide a serialization/deserialization API...
 
-* Serialization / deserialization to support broadcasting structured data.
-* Backends for Redis Streams, Apache Kafka, and RabbitMQ.
-* Add support for `subscribe('chatroom', history=100)` for backends which provide persistence. (Redis Streams, Apache Kafka) This will allow applications to subscribe to channel updates, while also being given an initial window onto the most recent events. We *might* also want to support some basic paging operations, to allow applications to scan back in the event history.
-* Support for pattern subscribes in backends that support it.
+- Serialization / deserialization to support broadcasting structured data.
+- Backends for Redis Streams, Apache Kafka, and RabbitMQ.
+- Add support for `subscribe('chatroom', history=100)` for backends which provide persistence. (Redis Streams, Apache Kafka) This will allow applications to subscribe to channel updates, while also being given an initial window onto the most recent events. We _might_ also want to support some basic paging operations, to allow applications to scan back in the event history.
+- Support for pattern subscribes in backends that support it.

--- a/broadcaster/_backends/kafka.py
+++ b/broadcaster/_backends/kafka.py
@@ -13,7 +13,8 @@ from .base import BroadcastBackend
 
 class KafkaBackend(BroadcastBackend):
     def __init__(self, url: str):
-        self._servers = [urlparse(url).netloc]
+        parsed_url = urlparse(url).netloc
+        self._servers = parsed_url.split(',')
         self._consumer_channels: typing.Set = set()
         self._security_protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL") or "PLAINTEXT"
         self._sasl_mechanism = os.environ.get("KAFKA_SASL_MECHANISM") or "PLAIN"

--- a/broadcaster/_backends/kafka.py
+++ b/broadcaster/_backends/kafka.py
@@ -1,8 +1,11 @@
+import os
 import asyncio
 import typing
+import logging
 from urllib.parse import urlparse
 
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+from aiokafka.helpers import create_ssl_context
 
 from .._base import Event
 from .base import BroadcastBackend
@@ -12,13 +15,40 @@ class KafkaBackend(BroadcastBackend):
     def __init__(self, url: str):
         self._servers = [urlparse(url).netloc]
         self._consumer_channels: typing.Set = set()
+        self._security_protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL") or "PLAINTEXT"
+        self._sasl_mechanism = os.environ.get("KAFKA_SASL_MECHANISM") or "PLAIN"
+        self._sasl_plain_username = os.environ.get("KAFKA_PLAIN_USERNAME")
+        self._sasl_plain_password = os.environ.get("KAFKA_PLAIN_PASSWORD")
+        self._ssl_context = create_ssl_context() if self._security_protocol in ["SSL", "SASL_SSL"] else None
 
     async def connect(self) -> None:
-        loop = asyncio.get_event_loop()
-        self._producer = AIOKafkaProducer(loop=loop, bootstrap_servers=self._servers)
-        self._consumer = AIOKafkaConsumer(loop=loop, bootstrap_servers=self._servers)
-        await self._producer.start()
-        await self._consumer.start()
+        logging.info(f"connecting to brokers: {self._servers}")
+        try:
+            loop = asyncio.get_event_loop()
+            self._producer = AIOKafkaProducer(
+                loop=loop,
+                bootstrap_servers=self._servers,
+                security_protocol=self._security_protocol,
+                ssl_context=self._ssl_context,
+                sasl_mechanism=self._sasl_mechanism,
+                sasl_plain_username=self._sasl_plain_username,
+                sasl_plain_password=self._sasl_plain_password,
+            )
+            self._consumer = AIOKafkaConsumer(
+                loop=loop,
+                bootstrap_servers=self._servers,
+                security_protocol=self._security_protocol,
+                ssl_context=self._ssl_context,
+                sasl_mechanism=self._sasl_mechanism,
+                sasl_plain_username=self._sasl_plain_username,
+                sasl_plain_password=self._sasl_plain_password,
+            )
+            await self._producer.start()
+            await self._consumer.start()
+        except Exception as e:
+            logging.error(e)
+            raise e
+
 
     async def disconnect(self) -> None:
         await self._producer.stop()

--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -1,3 +1,4 @@
+import logging
 import asyncio
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, AsyncIterator, Dict, Optional

--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -1,4 +1,3 @@
-import logging
 import asyncio
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, AsyncIterator, Dict, Optional


### PR DESCRIPTION
- Adds SASL connection support for Kafka via environment variables
- Adds support for connecting to multiple Kafka brokers

Built with OPAL server and tested:
- running in local OPAL docker compose configuration (with plain text - i.e. no SASL auth - as before)
- running in deployed configuration connecting to AWS MSK configured with SASL.