### PR TITLE
Postgres Backend: Acquire connections from pool

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     services:
       zookeeper:

--- a/broadcaster/__init__.py
+++ b/broadcaster/__init__.py
@@ -1,4 +1,4 @@
 from ._base import Broadcast, Event
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __all__ = ["Broadcast", "Event"]

--- a/broadcaster/_backends/postgres.py
+++ b/broadcaster/_backends/postgres.py
@@ -2,10 +2,15 @@ import asyncio
 from typing import Any
 
 import asyncpg
+import os
 
 from .._base import Event
 from .base import BroadcastBackend
 
+try:
+    POOL_MAX_SIZE = int(os.getenv("BROADCASTER_PG_MAX_POOL_SIZE"))
+except TypeError:
+    POOL_MAX_SIZE = 10
 
 class PostgresBackend(BroadcastBackend):
     _pools = {}
@@ -17,7 +22,7 @@ class PostgresBackend(BroadcastBackend):
     async def _get_pool(self):
         async with self.__class__._pools_lock:
             if self._url not in self.__class__._pools:
-                self.__class__._pools[self._url] = await asyncpg.create_pool(self._url)
+                self.__class__._pools[self._url] = await asyncpg.create_pool(self._url, max_size=POOL_MAX_SIZE)
             return self.__class__._pools[self._url]
 
     async def connect(self) -> None:


### PR DESCRIPTION
Using a connection pool rather than creating a new connection every time would benefit performance greatly.
The pool is a class member, acting as a global pool that serves every broadcaster instance. 
The default size of the pool is 10, but it's configurable through an envar in case we want a different value.