### PR TITLE
Postgres: Safe removal of listeners on unsubscribe + disconnect

### DIFF
--- a/broadcaster/__init__.py
+++ b/broadcaster/__init__.py
@@ -1,4 +1,4 @@
 from ._base import Broadcast, Event
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 __all__ = ["Broadcast", "Event"]


### PR DESCRIPTION
turn out asyncpg.Pool.acquire returns PoolConnectionProxy rather than an Connection. This proxy is detached from actual connection when the it's closed - so there's no way to check if the connection is still connected besides trying and catching exceptions