### PR TITLE
SQLAlchemy 2 with psycopg 3 Postgresql support

### DIFF
--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -37,8 +37,10 @@ class Broadcast:
 
             self._backend = RedisBackend(url)
 
-        elif parsed_url.scheme in ("postgres", "postgresql"):
+        elif parsed_url.scheme in ("postgres", "postgresql", "postgresql+psycopg"):
             from broadcaster._backends.postgres import PostgresBackend
+            # NOTE: SQLAlchemy 2 with psycopg 3 uses "postgresql+psycopg" scheme
+            # https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg
 
             self._backend = PostgresBackend(url)
 

--- a/broadcaster/_base.py
+++ b/broadcaster/_base.py
@@ -39,8 +39,6 @@ class Broadcast:
 
         elif parsed_url.scheme in ("postgres", "postgresql", "postgresql+psycopg"):
             from broadcaster._backends.postgres import PostgresBackend
-            # NOTE: SQLAlchemy 2 with psycopg 3 uses "postgresql+psycopg" scheme
-            # https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg
 
             self._backend = PostgresBackend(url)
 


### PR DESCRIPTION
Per the SQLAlchemy 2 documentation, a different Postgresql scheme is required for psycopg 3:
https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg