### PR TITLE
Postgres backend: TCP keepalive on pooled connections (detect half-open LISTEN after failover) — 0.2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test.db
 venv/
 build/
 dist/
+.venv/

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ Python 3.7+
 * `Broadcast("kafka://broker_1:9092,broker_2:9092")`
 
 
+## Postgres TCP keepalive
+
+A `LISTEN` connection is idle by nature: it sends nothing and waits for `NOTIFY`s. If the
+server's address goes silent without closing the socket (e.g. an RDS Multi-AZ failover, a
+network partition) the client never receives a FIN/RST, the socket stays `ESTABLISHED`, and
+the listener is deaf with no error. asyncpg exposes no keepalive option, so the Postgres
+backend enables TCP keepalive on every pooled connection itself. It is **on by default**
+(idle 30 s, 10 s between probes, 3 lost probes → the connection errors within ~60 s of the
+peer going silent and the subscriber is notified). Tune or disable it with the libpq
+parameter names in the URL (they are stripped before the URL reaches asyncpg):
+
+```
+postgres://user:pw@host:5432/db?keepalives=1&keepalives_idle=30&keepalives_interval=10&keepalives_count=3
+postgres://user:pw@host:5432/db?keepalives=0     # disable
+```
+
+The existing `BROADCASTER_PG_MAX_POOL_SIZE` environment variable still controls the pool size.
+
 ## Kafka environment variables
 
 The following environment variables are exposed to allow SASL authentication with Kafka (along with their default assignment):

--- a/broadcaster/__init__.py
+++ b/broadcaster/__init__.py
@@ -1,4 +1,4 @@
 from ._base import Broadcast, Event
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 __all__ = ["Broadcast", "Event"]

--- a/broadcaster/_backends/postgres.py
+++ b/broadcaster/_backends/postgres.py
@@ -1,28 +1,144 @@
 import asyncio
-from typing import Any
+import logging
+import os
+import socket
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import asyncpg
-import os
 
 from .._base import Event
 from .base import BroadcastBackend
+
+logger = logging.getLogger(__name__)
 
 try:
     POOL_MAX_SIZE = int(os.getenv("BROADCASTER_PG_MAX_POOL_SIZE"))
 except TypeError:
     POOL_MAX_SIZE = 10
 
+# TCP keepalive on the Postgres connections.
+#
+# A LISTEN connection is idle by nature: it sends nothing and waits for NOTIFYs.
+# If the server's address goes silent without closing the socket (RDS Multi-AZ
+# failover, network partition, node death) the client never receives a FIN/RST,
+# the kernel keeps the socket ESTABLISHED forever, and the listener is deaf
+# without any error. libpq clients get SO_KEEPALIVE for free (``keepalives=1``
+# is the libpq default); asyncpg exposes no such option (MagicStack/asyncpg#606),
+# so we set it on the socket ourselves, with the libpq parameter names so the
+# knobs look familiar in the URL:
+#
+#   postgres://user:pw@host/db?keepalives=1&keepalives_idle=30&keepalives_interval=10&keepalives_count=3
+#
+# Defaults: on, 30 s idle, 10 s between probes, 3 lost probes -> the connection
+# errors within ~60 s of the peer going silent and asyncpg's termination
+# listener fires. ``keepalives=0`` disables it. The parameters are stripped from
+# the URL before it reaches asyncpg (asyncpg would otherwise forward unknown
+# query parameters to the server as session settings).
+KEEPALIVE_PARAMS = (
+    "keepalives",
+    "keepalives_idle",
+    "keepalives_interval",
+    "keepalives_count",
+)
+DEFAULT_KEEPALIVE: Dict[str, int] = {
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+}
+
+
+def split_keepalive_options(url: str) -> Tuple[str, Dict[str, int]]:
+    """Return ``(url_without_keepalive_params, keepalive_options)``.
+
+    Unknown or absent parameters fall back to DEFAULT_KEEPALIVE; a value that is
+    not an integer raises ValueError (a typo in the URL should not silently turn
+    keepalive off).
+    """
+    parts = urlsplit(url)
+    options = dict(DEFAULT_KEEPALIVE)
+    remaining = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if key in KEEPALIVE_PARAMS:
+            options[key] = int(value)
+        else:
+            remaining.append((key, value))
+    clean_url = urlunsplit(parts._replace(query=urlencode(remaining)))
+    return clean_url, options
+
+
+def apply_tcp_keepalive(sock: Any, idle: int, interval: int, count: int) -> bool:
+    """Enable TCP keepalive on ``sock`` with the given timings (seconds).
+
+    Linux names the timers TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT; macOS
+    spells idle ``TCP_KEEPALIVE``; platforms exposing none of them still get
+    SO_KEEPALIVE with the kernel defaults. Returns True if SO_KEEPALIVE was set.
+    Never raises: a socket that refuses an option (e.g. a Unix socket) is left as
+    is and the failure is logged.
+    """
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except (OSError, AttributeError) as exc:
+        logger.warning("could not enable SO_KEEPALIVE on the Postgres socket: %r", exc)
+        return False
+    idle_opt = getattr(socket, "TCP_KEEPIDLE", None) or getattr(
+        socket, "TCP_KEEPALIVE", None
+    )
+    for opt, value in (
+        (idle_opt, idle),
+        (getattr(socket, "TCP_KEEPINTVL", None), interval),
+        (getattr(socket, "TCP_KEEPCNT", None), count),
+    ):
+        if opt is None or value is None or int(value) <= 0:
+            continue
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, opt, int(value))
+        except OSError as exc:
+            logger.warning(
+                "could not set TCP keepalive option %s=%s: %r", opt, value, exc
+            )
+    return True
+
+
+def _socket_of(conn: Any) -> Optional[Any]:
+    transport = getattr(conn, "_transport", None)
+    if transport is None:
+        return None
+    return transport.get_extra_info("socket")
+
+
 class PostgresBackend(BroadcastBackend):
-    _pools = {}
+    _pools: Dict[str, Any] = {}
     _pools_lock = asyncio.Lock()
 
     def __init__(self, url: str):
         self._url = url
+        self._dsn, self._keepalive = split_keepalive_options(url)
 
-    async def _get_pool(self):
+    async def _init_connection(self, conn: Any) -> None:
+        """asyncpg pool ``init`` hook: runs once for every new connection."""
+        if not self._keepalive["keepalives"]:
+            return
+        sock = _socket_of(conn)
+        if sock is None:
+            logger.warning(
+                "asyncpg connection exposes no socket; TCP keepalive not applied"
+            )
+            return
+        apply_tcp_keepalive(
+            sock,
+            self._keepalive["keepalives_idle"],
+            self._keepalive["keepalives_interval"],
+            self._keepalive["keepalives_count"],
+        )
+
+    async def _get_pool(self) -> Any:
         async with self.__class__._pools_lock:
             if self._url not in self.__class__._pools:
-                self.__class__._pools[self._url] = await asyncpg.create_pool(self._url, max_size=POOL_MAX_SIZE)
+                self.__class__._pools[self._url] = await asyncpg.create_pool(
+                    self._dsn, max_size=POOL_MAX_SIZE, init=self._init_connection
+                )
             return self.__class__._pools[self._url]
 
     async def connect(self) -> None:

--- a/tests/test_postgres_keepalive.py
+++ b/tests/test_postgres_keepalive.py
@@ -1,0 +1,165 @@
+"""TCP keepalive on the Postgres backend.
+
+Why: a LISTEN connection is idle by nature. If the server's address goes silent
+without closing the socket (RDS Multi-AZ failover, partition) the client never
+gets a FIN/RST and, without keepalive, stays ESTABLISHED-and-deaf forever.
+asyncpg exposes no keepalive option, so the backend sets it on the socket.
+"""
+import socket
+
+import pytest
+
+from broadcaster import Broadcast
+from broadcaster._backends.postgres import (
+    DEFAULT_KEEPALIVE,
+    PostgresBackend,
+    apply_tcp_keepalive,
+    split_keepalive_options,
+)
+
+PG_URL = "postgres://postgres:postgres@localhost:5432/broadcaster"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_pools():
+    """The backend caches asyncpg pools per URL at class level; a pool is bound to
+    the event loop that created it and pytest-asyncio gives every test its own
+    loop, so start and end each test with an empty cache."""
+    PostgresBackend._pools = {}
+    yield
+    PostgresBackend._pools = {}
+
+
+# --- URL parsing (no database needed) ---------------------------------------
+
+
+def test_defaults_when_url_has_no_keepalive_params():
+    clean, opts = split_keepalive_options(PG_URL)
+    assert clean == PG_URL
+    assert opts == DEFAULT_KEEPALIVE
+    assert opts["keepalives"] == 1  # on by default, like libpq
+
+
+def test_libpq_style_params_are_honoured_and_stripped_from_the_dsn():
+    url = (
+        PG_URL
+        + "?keepalives_idle=5&sslmode=require&keepalives_interval=2&keepalives_count=7"
+    )
+    clean, opts = split_keepalive_options(url)
+    assert opts == {
+        "keepalives": 1,
+        "keepalives_idle": 5,
+        "keepalives_interval": 2,
+        "keepalives_count": 7,
+    }
+    # our params must not reach asyncpg (it forwards unknown query params to the
+    # server as session settings, which would fail the connection); other
+    # params are preserved.
+    assert clean == PG_URL + "?sslmode=require"
+
+
+def test_keepalives_zero_disables():
+    _, opts = split_keepalive_options(PG_URL + "?keepalives=0")
+    assert opts["keepalives"] == 0
+
+
+def test_non_integer_value_is_an_error_not_a_silent_default():
+    with pytest.raises(ValueError):
+        split_keepalive_options(PG_URL + "?keepalives_idle=soon")
+
+
+def test_backend_parses_its_url_on_construction():
+    backend = PostgresBackend(PG_URL + "?keepalives_idle=11")
+    assert backend._dsn == PG_URL
+    assert backend._keepalive["keepalives_idle"] == 11
+
+
+# --- socket options on a real TCP socket (no database needed) -----------------
+
+
+def _tcp_pair():
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    client = socket.create_connection(server.getsockname())
+    peer, _ = server.accept()
+    return client, peer, server
+
+
+def test_apply_tcp_keepalive_sets_the_options():
+    client, peer, server = _tcp_pair()
+    try:
+        assert apply_tcp_keepalive(client, idle=5, interval=2, count=3) is True
+        assert (
+            client.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) != 0
+        )  # macOS returns the option bit (8), Linux 1
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            assert client.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL) == 2
+        if hasattr(socket, "TCP_KEEPCNT"):
+            assert client.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT) == 3
+        idle_opt = getattr(socket, "TCP_KEEPIDLE", None) or getattr(
+            socket, "TCP_KEEPALIVE", None
+        )
+        if idle_opt is not None:
+            assert client.getsockopt(socket.IPPROTO_TCP, idle_opt) == 5
+    finally:
+        client.close()
+        peer.close()
+        server.close()
+
+
+def test_apply_tcp_keepalive_never_raises_on_a_closed_socket():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.close()
+    assert apply_tcp_keepalive(sock, idle=5, interval=2, count=3) is False
+
+
+# --- end to end against the test Postgres -------------------------------------
+
+
+def _listener_socket(broadcast: Broadcast):
+    # the pooled connection is a proxy; the real asyncpg Connection is ._con
+    conn = broadcast._backend._conn
+    inner = getattr(conn, "_con", conn)
+    return inner._transport.get_extra_info("socket")
+
+
+@pytest.mark.asyncio
+async def test_pool_connections_get_keepalive_by_default():
+    async with Broadcast(PG_URL) as broadcast:
+        sock = _listener_socket(broadcast)
+        assert (
+            sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) != 0
+        )  # macOS returns the option bit (8), Linux 1
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            assert (
+                sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL)
+                == DEFAULT_KEEPALIVE["keepalives_interval"]
+            )
+
+
+@pytest.mark.asyncio
+async def test_pool_connections_honour_url_params():
+    # distinct URL -> distinct pool (pools are keyed by the full URL)
+    url = PG_URL + "?keepalives_idle=7&keepalives_interval=4&keepalives_count=2"
+    async with Broadcast(url) as broadcast:
+        sock = _listener_socket(broadcast)
+        assert (
+            sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) != 0
+        )  # macOS returns the option bit (8), Linux 1
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            assert sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL) == 4
+        if hasattr(socket, "TCP_KEEPCNT"):
+            assert sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT) == 2
+        # and the connection still works end to end
+        async with broadcast.subscribe("chatroom") as subscriber:
+            await broadcast.publish("chatroom", "hello")
+            event = await subscriber.get()
+            assert event.message == "hello"
+
+
+@pytest.mark.asyncio
+async def test_keepalives_zero_leaves_the_socket_alone():
+    async with Broadcast(PG_URL + "?keepalives=0") as broadcast:
+        sock = _listener_socket(broadcast)
+        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) == 0


### PR DESCRIPTION
## What

The Postgres backend now enables **TCP keepalive on every pooled asyncpg connection**, on by default (idle 30 s / interval 10 s / count 3 → a silently vanished server is detected within ~60 s), tunable or disableable with the **libpq parameter names in the URL**:

```
postgres://user:pw@host:5432/db?keepalives=1&keepalives_idle=30&keepalives_interval=10&keepalives_count=3
postgres://user:pw@host:5432/db?keepalives=0   # off
```

The parameters are stripped before the DSN reaches asyncpg (asyncpg forwards unknown query params to the server as session settings, which would fail the connection). Version bumped to **0.2.7**.

## Why

A `LISTEN` connection is idle by nature: it sends nothing and waits for `NOTIFY`s. When the server's address goes silent *without* closing the socket — an RDS Multi-AZ failover, a network partition, a dead node — the client never receives a FIN/RST, the kernel keeps the socket `ESTABLISHED` forever, and the listener is deaf with no error and no event to react to. Publishers in the same process notice on their next `pg_notify`, reconnect by DNS name and land on the new primary — so the process ends up **notifying the new primary while still listening on the old one**. This is exactly what happened to opal-server on an RDS failover (details in the internal incident report).

libpq-based clients get `SO_KEEPALIVE` for free (`keepalives=1` is the libpq default); asyncpg exposes no keepalive option at all — [MagicStack/asyncpg#606](https://github.com/MagicStack/asyncpg/issues/606) (open since 2020; the maintainer's suggested workaround is exactly this: set it on the transport socket) and [#519](https://github.com/MagicStack/asyncpg/issues/519). AWS's own guidance for Postgres failover is to turn TCP keepalives on, aggressively ([Fast failover with Aurora PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.BestPractices.FastFailover.html)).

Scope: this only makes the dead connection *error*; reconnecting is, as before, the caller's job (the subscriber gets `Unsubscribed`, the termination listener fires). It does not cover a peer whose kernel is alive but whose Postgres is mute — TCP keepalive cannot see that; an application-level heartbeat is the tool for that case.

## Verification

Isolated lab: `postgres:16` + this backend on one docker bridge network, the server cut with `docker network disconnect` (the address goes silent, like a failover — unlike `docker stop/kill`, which send FIN/RST and were always detected in ~1 s):

| backend | subscriber learns the connection died after |
|---|---|
| 0.2.6 | never (socket still `ESTABLISHED` at +10 min) |
| this PR, defaults 30/10/3 | **61.8 s** |
| this PR, `?keepalives_idle=5&keepalives_interval=2&keepalives_count=3` | **12.3 s** |

Tests (`tests/test_postgres_keepalive.py`, 11 tests): URL parsing/stripping/defaults/`keepalives=0`/non-integer → `ValueError`; `apply_tcp_keepalive` on a real TCP socket (asserts `getsockopt`), never raises on a bad socket; end to end against the test Postgres: pooled connections carry the options by default, honour URL params, and `keepalives=0` leaves the socket alone. Ran locally on Python 3.11 against `postgres:16`, plus `test_memory`/`test_postgres` from the existing suite.

Notes for reviewers
- `getsockopt(SO_KEEPALIVE)` returns `8` on macOS and `1` on Linux — tests assert non-zero.
- The tests reset `PostgresBackend._pools` around each test: the class-level pool cache is bound to the event loop that created it and pytest-asyncio gives each test its own loop (pre-existing; surfaced by having more than one Postgres test).
- `.venv/` added to `.gitignore`.

## Release

After merge: tag `0.2.7` → `publish.yml` builds and uploads (`scripts/publish`, needs the `PYPI_TOKEN` secret; 0.2.6 appears to have been uploaded by hand in Dec 2024 — worth confirming the secret exists before relying on the workflow). Then bump `permit-broadcaster[postgres,redis,kafka]==0.2.7` in OPAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxg7e1Jtk5qykAdYoYENdw
