### PR TITLE
scripts/publish: fix sh-incompatible &> redirect (why the 0.2.7 Publish run failed)

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -8,13 +8,13 @@ fi
 
 scripts/clean
 
-if ! command -v "${PREFIX}twine" &>/dev/null ; then
+if ! command -v "${PREFIX}twine" >/dev/null 2>&1 ; then
     echo "Unable to find the 'twine' command."
     echo "Install from PyPI, using '${PREFIX}pip install twine'."
     exit 1
 fi
 
-if ! command -v "${PREFIX}wheel" &>/dev/null ; then
+if ! command -v "${PREFIX}wheel" >/dev/null 2>&1 ; then
     echo "Unable to find the 'wheel' command."
     echo "Install from PyPI, using '${PREFIX}pip install wheel'."
     exit 1


### PR DESCRIPTION
The publish workflow's failure on tag 0.2.7 was not a missing dependency: twine was installed (its path is line 15 of the run log). `scripts/publish` runs under `#!/bin/sh`, and dash does not implement the bash-only `&>` operator, so `command -v twine &>/dev/null` misparses and the not-found branch fires unconditionally. Replaced both occurrences with `>/dev/null 2>&1`. (`scripts/start_pulsar` keeps its `&>` — it declares `#!/bin/bash`.)

With this + a valid `PYPI_TOKEN` secret, the next tag push should publish cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxg7e1Jtk5qykAdYoYENdw