### PR TITLE
publish.yml: allow manual dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch: {}
 
 jobs:
   publish:


### PR DESCRIPTION
Adds `workflow_dispatch` to the Publish workflow (the commit that missed the #29 merge window). Lets us re-run a publish from master without deleting and re-pushing a tag — `scripts/publish` reads the version from `broadcaster/__init__.py`, so no tag context is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxg7e1Jtk5qykAdYoYENdw